### PR TITLE
OFS-113: Create new Contribution Plan

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "build": "rollup -c",
     "start": "rollup -c -w"
   },
-  "peerDependency": {
-    "react-intl": "^5.8.1"
-  },
+  "peerDependency": {},
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.6",
@@ -33,6 +31,7 @@
     "moment": "^2.25.3",
     "prop-types": "^15.7.2",
     "react-autosuggest": "^10.0.2",
+    "react-intl": "^5.8.1",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
     "redux-api-middleware": "^3.2.1",

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,12 +1,16 @@
 import {
-    graphql, formatPageQueryWithCount
+    graphql, formatPageQueryWithCount, formatMutation, decodeId, formatGQLString
 } from "@openimis/fe-core";
 
 const CONTRIBUTIONPLAN_FULL_PROJECTION = (modulesManager) => [
-    "id", "code", "name", 
+    "id", "code", "name", "calculation{id}",
     "benefitPlan" + modulesManager.getProjection("product.ProductPicker.projection"),
     "periodicity", "dateValidFrom", "dateValidTo"
 ];
+
+function dateTimeToDate(date) {
+    return date.split('T')[0];
+}
 
 export function fetchContributionPlans(modulesManager, params) {
     const payload = formatPageQueryWithCount(
@@ -15,4 +19,31 @@ export function fetchContributionPlans(modulesManager, params) {
         CONTRIBUTIONPLAN_FULL_PROJECTION(modulesManager)
     );
     return graphql(payload, "CONTRIBUTIONPLAN_CONTRIBUTIONPLANS");
+}
+
+function formatContributionPlanGQL(contributionPlan) {
+    return `
+        ${!!contributionPlan.id ? `id: "${decodeId(contributionPlan.id)}"` : ''}
+        ${!!contributionPlan.code ? `code: "${formatGQLString(contributionPlan.code)}"` : ""}
+        ${!!contributionPlan.name ? `name: "${formatGQLString(contributionPlan.name)}"` : ""}
+        ${!!contributionPlan.calculation ? `calculationId: "${contributionPlan.calculation}"` : ""} 
+        ${!!contributionPlan.benefitPlan ? `benefitPlanId: ${decodeId(contributionPlan.benefitPlan.id)}` : ""}
+        ${!!contributionPlan.periodicity ? `periodicity: ${contributionPlan.periodicity}` : ""}
+        ${!!contributionPlan.dateValidFrom ? `dateValidFrom: "${dateTimeToDate(contributionPlan.dateValidFrom)}"` : ""}
+        ${!!contributionPlan.dateValidTo ? `dateValidTo: "${dateTimeToDate(contributionPlan.dateValidTo)}"` : ""}
+    `;
+}
+
+export function createContributionPlan(contributionPlan, clientMutationLabel) {
+    let mutation = formatMutation("createContributionPlan", formatContributionPlanGQL(contributionPlan), clientMutationLabel);
+    var requestedDateTime = new Date();
+    return graphql(
+        mutation.payload,
+        ["CONTRIBUTIONPLAN_MUTATION_REQ", "CONTRIBUTIONPLAN_CREATE_CONTRIBUTIONPLAN_RESP", "CONTRIBUTIONPLAN_MUTATION_ERR"],
+        {
+            clientMutationId: mutation.clientMutationId,
+            clientMutationLabel,
+            requestedDateTime
+        }
+    );
 }

--- a/src/components/ContributionPlanFilter.js
+++ b/src/components/ContributionPlanFilter.js
@@ -3,11 +3,8 @@ import { injectIntl } from 'react-intl';
 import { withModulesManager, formatMessage, TextInput, NumberInput, PublishedComponent } from "@openimis/fe-core";
 import { Grid, FormControlLabel, Checkbox } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { DATE_TO_DATETIME_SUFFIX, GREATER_OR_EQUAL_LOOKUP, LESS_OR_EQUAL_LOOKUP, CONTAINS_LOOKUP } from "../constants"
-
-const EMPTY_PERIODICITY_FILTER = 0;
-const MIN_PERIODICITY_FILTER = 1;
-const MAX_PERIODICITY_FILTER = 12;
+import { DATE_TO_DATETIME_SUFFIX, GREATER_OR_EQUAL_LOOKUP, LESS_OR_EQUAL_LOOKUP, CONTAINS_LOOKUP,
+    EMPTY_PERIODICITY_FILTER, MIN_PERIODICITY_FILTER, MAX_PERIODICITY_FILTER } from "../constants"
 
 const styles = theme => ({
     dialogTitle: theme.dialog.title,

--- a/src/components/ContributionPlanForm.js
+++ b/src/components/ContributionPlanForm.js
@@ -1,0 +1,86 @@
+import React, { Component, Fragment } from "react";
+import { Form, withModulesManager, withHistory, formatMessage, journalize } from "@openimis/fe-core";
+import { injectIntl } from "react-intl";
+import { withTheme, withStyles } from "@material-ui/core/styles";
+import { bindActionCreators } from "redux";
+import { connect } from "react-redux";
+import ContributionPlanHeadPanel from "./ContributionPlanHeadPanel"
+
+const styles = theme => ({
+    paper: theme.paper.paper,
+    paperHeader: theme.paper.header,
+    paperHeaderAction: theme.paper.action,
+    item: theme.paper.item,
+});
+
+class ContributionPlanForm extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            contributionPlan: {}
+        };
+    }
+
+    componentDidMount() {
+        document.title = formatMessage(this.props.intl, "contributionPlan", "contributionPlan.page.title")
+    }
+
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        if (prevProps.submittingMutation && !this.props.submittingMutation) {
+            this.props.journalize(this.props.mutation);
+        }
+    }
+
+    isMandatoryFieldsEmpty = () => {
+        const { contributionPlan } = this.state;
+        if (!!contributionPlan.code
+            && !!contributionPlan.name
+            && !!contributionPlan.calculation
+            && !!contributionPlan.benefitPlan
+            && !!contributionPlan.periodicity
+            && !!contributionPlan.dateValidFrom) {
+            return false;
+        }
+        return true;
+    }
+
+    canSave = () => !this.isMandatoryFieldsEmpty();
+
+    save = contributionPlan => this.props.save(contributionPlan);
+
+    onEditedChanged = contributionPlan => this.setState({ contributionPlan })
+
+    titleParams = () => this.props.titleParams(this.state.contributionPlan);
+
+    render() {
+        const { intl, back } = this.props;
+        return (
+            <Fragment>
+                <Form
+                    module="contributionPlan"
+                    title="contributionPlan.page.title"
+                    titleParams={this.titleParams()}
+                    edited={this.state.contributionPlan}
+                    back={back}
+                    canSave={this.canSave}
+                    save={this.save}
+                    onEditedChanged={this.onEditedChanged}
+                    HeadPanel={ContributionPlanHeadPanel}
+                    mandatoryFieldsEmpty={this.isMandatoryFieldsEmpty()}
+                    saveTooltip={formatMessage(intl, "contributionPlan", `saveContributionPlanButton.tooltip.${this.canSave() ? 'enabled' : 'disabled'}`)} 
+                />
+            </Fragment>
+        )
+    }
+}
+
+const mapStateToProps = state => ({
+    submittingMutation: state.contributionPlan.submittingMutation,
+    mutation: state.contributionPlan.mutation
+});
+
+const mapDispatchToProps = dispatch => {
+    return bindActionCreators({ journalize }, dispatch);
+};
+
+export default withHistory(withModulesManager(injectIntl(withTheme(withStyles(styles)(connect(mapStateToProps, mapDispatchToProps)(ContributionPlanForm))))));

--- a/src/components/ContributionPlanHeadPanel.js
+++ b/src/components/ContributionPlanHeadPanel.js
@@ -1,0 +1,123 @@
+import React, { Fragment } from "react";
+import { Grid, Divider, Typography } from "@material-ui/core";
+import { withModulesManager, formatMessage, FormPanel, TextInput,
+    FormattedMessage, PublishedComponent, NumberInput } from "@openimis/fe-core";
+import { injectIntl } from "react-intl";
+import { withTheme, withStyles } from "@material-ui/core/styles";
+import { EMPTY_PERIODICITY_FILTER, MIN_PERIODICITY_FILTER, MAX_PERIODICITY_FILTER } from "../constants"
+
+const styles = theme => ({
+    tableTitle: theme.table.title,
+    item: theme.paper.item,
+    fullHeight: {
+        height: "100%"
+    }
+});
+
+class ContributionPlanHeadPanel extends FormPanel {
+    render() {
+        const { intl, classes, edited, mandatoryFieldsEmpty } = this.props;
+        return (
+            <Fragment>
+                <Grid container className={classes.tableTitle}>
+                    <Grid item>
+                        <Grid container align="center" justify="center" direction="column" className={classes.fullHeight}>
+                            <Grid item>
+                                <Typography >
+                                    <FormattedMessage module="contributionPlan" id="contributionPlan.headPanel.title" />
+                                </Typography>
+                            </Grid>
+                        </Grid>
+                    </Grid>
+                </Grid>
+                <Divider />
+                {mandatoryFieldsEmpty &&
+                    <Fragment>
+                        <div className={classes.item}>
+                            <FormattedMessage module="contributionPlan" id="mandatoryFieldsEmptyError" />
+                        </div>
+                        <Divider />
+                    </Fragment>
+                }
+                <Grid container className={classes.item}>
+                    <Grid item xs={3} className={classes.item}>
+                        <TextInput
+                            module="contributionPlan"
+                            label="code"
+                            required
+                            value={!!edited && !!edited.code ? edited.code : ""}
+                            onChange={v => this.updateAttribute('code', v)}
+                            readOnly={!!edited && !!edited.id ? true : false}
+                        />
+                    </Grid>
+                    <Grid item xs={3} className={classes.item}>
+                        <TextInput
+                            module="contributionPlan"
+                            label="name"
+                            required
+                            value={!!edited && !!edited.name ? edited.name : ""}
+                            onChange={v => this.updateAttribute('name', v)}
+                        />
+                    </Grid>
+                    <Grid item xs={3} className={classes.item}>
+                        <TextInput
+                            /**
+                             * a @see TextInput until @see Calculation module provides a picker
+                             */
+                            module="contributionPlan"
+                            label="calculation"
+                            required
+                            value={!!edited && !!edited.calculation ? edited.calculation : ""}
+                            onChange={v => this.updateAttribute('calculation', v)}
+                        />
+                    </Grid>
+                    <Grid item xs={3} className={classes.item}>
+                        <PublishedComponent
+                            pubRef="product.ProductPicker"
+                            withNull={true}
+                            label={formatMessage(intl, "contributionPlan", "benefitPlan")}
+                            required
+                            value={!!edited && !!edited.benefitPlan ? edited.benefitPlan : null}
+                            onChange={v => this.updateAttribute('benefitPlan', v)}
+                        />
+                    </Grid>
+                    <Grid item xs={3} className={classes.item}>
+                        <NumberInput
+                            module="contributionPlan"
+                            label="periodicity"
+                            required
+                            /**
+                             * @see min set to @see EMPTY_PERIODICITY_FILTER when filter unset to avoid @see NumberInput error message
+                             */
+                            min={!!edited && !!edited.periodicity ? MIN_PERIODICITY_FILTER : EMPTY_PERIODICITY_FILTER}
+                            max={MAX_PERIODICITY_FILTER}
+                            value={!!edited && !!edited.periodicity ? edited.periodicity : null}
+                            onChange={v => this.updateAttribute('periodicity', v)}
+                        />
+                    </Grid>
+                    <Grid item xs={3} className={classes.item}>
+                        <PublishedComponent
+                            pubRef="core.DatePicker"
+                            module="contributionPlan"
+                            label="dateValidFrom"
+                            required
+                            value={!!edited && !!edited.dateValidFrom ? edited.dateValidFrom : null}
+                            onChange={v => this.updateAttribute('dateValidFrom', v)}
+                        />
+                    </Grid>
+                    <Grid item xs={3} className={classes.item}>
+                        <PublishedComponent
+                            pubRef="core.DatePicker"
+                            module="contributionPlan"
+                            label="dateValidTo"
+                            value={!!edited && !!edited.dateValidTo ? edited.dateValidTo : null}
+                            onChange={v => this.updateAttribute('dateValidTo', v)}
+                        />
+                    </Grid>
+                </Grid>
+            </Fragment>
+        )
+    }
+}
+
+export default withModulesManager(injectIntl(withTheme(withStyles(styles)(ContributionPlanHeadPanel))))

--- a/src/components/ContributionPlanSearcher.js
+++ b/src/components/ContributionPlanSearcher.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from "react"
 import { injectIntl } from 'react-intl';
-import { withModulesManager, formatMessageWithValues, formatDateFromISO, Searcher, PublishedComponent } from "@openimis/fe-core";
+import { withModulesManager, formatMessageWithValues, formatDateFromISO, Searcher, PublishedComponent, decodeId } from "@openimis/fe-core";
 import { fetchContributionPlans } from "../actions"
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
@@ -76,9 +76,9 @@ class ContributionPlanSearcher extends Component {
             contributionPlan => !!contributionPlan.code ? contributionPlan.code : "",
             contributionPlan => !!contributionPlan.name ? contributionPlan.name : "",
             /**
-             * empty until @see Calculation module provides a picker
+             * Display calculation's ID until @see Calculation module provides a picker
              */
-            _ => "", 
+            contributionPlan => !!contributionPlan.calculation ? decodeId(contributionPlan.calculation.id) : "",
             contributionPlan => 
                 <PublishedComponent
                     pubRef="product.ProductPicker"

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,3 +12,6 @@ export const DATE_TO_DATETIME_SUFFIX = "T00:00:00"
 export const GREATER_OR_EQUAL_LOOKUP = "Gte"
 export const LESS_OR_EQUAL_LOOKUP = "Lte"
 export const CONTAINS_LOOKUP = "Icontains"
+export const EMPTY_PERIODICITY_FILTER = 0
+export const MIN_PERIODICITY_FILTER = 1
+export const MAX_PERIODICITY_FILTER = 12

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,21 @@
 import messages_en from "./translations/en.json";
 import reducer from "./reducer";
 import ContributionPlansPage from "./pages/ContributionPlansPage";
+import ContributionPlanPage from "./pages/ContributionPlanPage";
 
 const ROUTE_CONTRIBUTION_PLANS = "contributionPlan/contributionPlans";
+const ROUTE_CONTRIBUTION_PLAN = "contributionPlan/contributionPlan";
 
 const DEFAULT_CONFIG = {
     "translations": [{ key: "en", messages: messages_en }],
     "reducers": [{ key: 'contributionPlan', reducer }],
+    "refs": [
+        { key: "contributionPlan.route.contributionPlans", ref: ROUTE_CONTRIBUTION_PLANS },
+        { key: "contributionPlan.route.contributionPlan", ref: ROUTE_CONTRIBUTION_PLAN }
+    ],
     "core.Router": [
         { path: ROUTE_CONTRIBUTION_PLANS, component: ContributionPlansPage },
+        { path: ROUTE_CONTRIBUTION_PLAN, component: ContributionPlanPage }
     ]
 }
 

--- a/src/pages/ContributionPlanPage.js
+++ b/src/pages/ContributionPlanPage.js
@@ -1,0 +1,58 @@
+import React, { Component } from "react"
+import { withModulesManager, withHistory, historyPush, formatMessageWithValues } from "@openimis/fe-core";
+import { injectIntl } from "react-intl";
+import { bindActionCreators } from "redux";
+import { connect } from "react-redux";
+import { withTheme, withStyles } from "@material-ui/core/styles";
+import { createContributionPlan } from "../actions"
+import ContributionPlanForm from "../components/ContributionPlanForm"
+import { RIGHT_CONTRIBUTION_PLAN_CREATE, RIGHT_CONTRIBUTION_PLAN_UPDATE } from "../constants"
+
+const styles = theme => ({
+    page: theme.page,
+});
+
+class ContributionPlanPage extends Component {
+    back = () => {
+        historyPush(this.props.modulesManager, this.props.history, "contributionPlan.route.contributionPlans")
+    }
+
+    save = contributionPlan => {
+        this.props.createContributionPlan(
+            contributionPlan,
+            formatMessageWithValues(
+                this.props.intl,
+                "contributionPlan",
+                "CreateContributionPlan.mutationLabel",
+                { label: this.titleParams(contributionPlan).label }
+            )
+        );
+    }
+
+    titleParams = contributionPlan => ({ label: !!contributionPlan.name ? contributionPlan.name : null });
+
+    render() {
+        const { classes, rights } = this.props;
+        return (
+            rights.includes(RIGHT_CONTRIBUTION_PLAN_CREATE) && rights.includes(RIGHT_CONTRIBUTION_PLAN_UPDATE) && (
+                <div className={classes.page}>
+                    <ContributionPlanForm
+                        back={this.back}
+                        save={this.save}
+                        titleParams={this.titleParams}
+                    />
+                </div>
+            )
+        )
+    }
+}
+
+const mapStateToProps = state => ({
+    rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : []
+});
+
+const mapDispatchToProps = dispatch => {
+    return bindActionCreators({ createContributionPlan }, dispatch);
+};
+
+export default withHistory(withModulesManager(injectIntl(withTheme(withStyles(styles)(connect(mapStateToProps, mapDispatchToProps)(ContributionPlanPage))))));

--- a/src/pages/ContributionPlansPage.js
+++ b/src/pages/ContributionPlansPage.js
@@ -1,13 +1,16 @@
 import React, { Component } from "react";
-import { withModulesManager, formatMessage } from "@openimis/fe-core";
+import { withModulesManager, formatMessage, withTooltip, historyPush } from "@openimis/fe-core";
 import { injectIntl } from "react-intl";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { connect } from "react-redux";
-import { RIGHT_CONTRIBUTION_PLAN_SEARCH } from "../constants"
+import { RIGHT_CONTRIBUTION_PLAN_SEARCH, RIGHT_CONTRIBUTION_PLAN_CREATE } from "../constants"
 import ContributionPlanSearcher from "../components/ContributionPlanSearcher";
+import { Fab } from "@material-ui/core";
+import AddIcon from "@material-ui/icons/Add";
 
 const styles = theme => ({
-    page: theme.page
+    page: theme.page,
+    fab: theme.fab
 })
 
 class ContributionPlansPage extends Component {
@@ -15,14 +18,26 @@ class ContributionPlansPage extends Component {
         document.title = formatMessage(this.props.intl, "contributionPlan", "contributionPlans.page.title");
     }
 
+    onAdd = () => {
+        historyPush(this.props.modulesManager, this.props.history, "contributionPlan.route.contributionPlan");
+    }
+
     render() {
-        const { classes, rights } = this.props;
+        const { intl, classes, rights } = this.props;
         return (
             rights.includes(RIGHT_CONTRIBUTION_PLAN_SEARCH) &&
                 <div className={classes.page}>
                     <ContributionPlanSearcher
                         rights={rights}
                     />
+                    {rights.includes(RIGHT_CONTRIBUTION_PLAN_CREATE) && withTooltip(
+                        <div className={classes.fab} >
+                            <Fab color="primary" onClick={this.onAdd}>
+                                <AddIcon />
+                            </Fab>
+                        </div>,
+                        formatMessage(intl, "contributionPlan", "createButton.tooltip")
+                    )}
                 </div>
         )
     }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,6 @@
 import {
-    formatServerError, formatGraphQLError, parseData, pageInfo
+    formatServerError, formatGraphQLError, parseData, pageInfo,
+    dispatchMutationReq, dispatchMutationResp, dispatchMutationErr
 } from "@openimis/fe-core";
 
 function reducer(
@@ -40,6 +41,12 @@ function reducer(
                 fetchingContributionPlans: false,
                 errorContributionPlans: formatServerError(action.payload)
             };
+        case "CONTRIBUTIONPLAN_MUTATION_REQ":
+            return dispatchMutationReq(state, action);
+        case "CONTRIBUTIONPLAN_MUTATION_ERR":
+            return dispatchMutationErr(state, action);
+        case "CONTRIBUTIONPLAN_CREATE_CONTRIBUTIONPLAN_RESP":
+            return dispatchMutationResp(state, "createContributionPlan", action);
         default:
             return state;
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9,5 +9,12 @@
     "contributionPlan.dateValidFrom": "Valid from",
     "contributionPlan.dateValidTo": "Valid to",
     "contributionPlan.isDeleted": "Show Deleted",
-    "contributionPlan.emptyLabel": " "
+    "contributionPlan.emptyLabel": " ",
+    "contributionPlan.createButton.tooltip": "Create new Contribution Plan",
+    "contributionPlan.contributionPlan.page.title": "Contribution Plan {label}",
+    "contributionPlan.contributionPlan.headPanel.title": "General Information",
+    "contributionPlan.mandatoryFieldsEmptyError": "* These fields are required",
+    "contributionPlan.saveContributionPlanButton.tooltip.enabled": "Save changes",
+    "contributionPlan.saveContributionPlanButton.tooltip.disabled": "Please fill General Information fields first",
+    "contributionPlan.CreateContributionPlan.mutationLabel": "Create Contribution Plan - {label}"
 }


### PR DESCRIPTION
As mentioned in the description of OFS-113, due to the lack of picker for `calculation` (that will be provided by `Calculation` module which is yet to be developed) the following, temporary behavior will have to be changed once the picker is provided:
- `id` of `calculation` is displayed in the search result table (instead of a string provided by picker)
- `id` of `calculation` has to be typed in explicitly on create page (instead of selecting `calculation` from picker)