### PR TITLE
OTC-1039: Typo fixed

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -401,7 +401,7 @@ function reducer(
           ...state.validationFields,
           contributionPlanBundleCode: {
             isValidating: false,
-            isValid: action.payload?.data?.validateContributionPlanCode,
+            isValid: action.payload?.data?.validateContributionPlanBundleCode,
             validationError: formatGraphQLError(action.payload),
           },
         },


### PR DESCRIPTION
[OTC-1039](https://openimis.atlassian.net/browse/OTC-1039)

Changes:
- Typo in _reducer.js_ has been fixed.

[OTC-1039]: https://openimis.atlassian.net/browse/OTC-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ