### PR TITLE
OP-1363: displaying string with code and name of a product instead of…

### DIFF
--- a/src/components/ContributionPlanSearcher.js
+++ b/src/components/ContributionPlanSearcher.js
@@ -6,7 +6,6 @@ import {
     formatMessageWithValues,
     formatDateFromISO,
     Searcher,
-    PublishedComponent,
     withTooltip,
     coreConfirm,
     journalize,
@@ -79,13 +78,7 @@ class ContributionPlanSearcher extends Component {
                     readOnly
                 /> : "",
             contributionPlan => !!contributionPlan.benefitPlan
-                ? <PublishedComponent
-                    pubRef="product.ProductPicker"
-                    withNull={true}
-                    withLabel={false}
-                    value={contributionPlan.benefitPlan}
-                    readOnly
-                /> : "",
+                ? `${contributionPlan.benefitPlan.code} ${contributionPlan.benefitPlan.name}` : "",
             contributionPlan => !!contributionPlan.periodicity ? contributionPlan.periodicity : "",
             contributionPlan => !!contributionPlan.dateValidFrom
                 ? formatDateFromISO(modulesManager, intl, contributionPlan.dateValidFrom)

--- a/src/components/PaymentPlanSearcher.js
+++ b/src/components/PaymentPlanSearcher.js
@@ -6,7 +6,6 @@ import {
     formatMessageWithValues,
     formatDateFromISO,
     Searcher,
-    PublishedComponent,
     withTooltip,
     coreConfirm,
     journalize,
@@ -84,13 +83,7 @@ class PaymentPlanSearcher extends Component {
                     readOnly
                 /> : "",
                 paymentPlan => !!paymentPlan.benefitPlan
-                ? <PublishedComponent
-                    pubRef="product.ProductPicker"
-                    withNull={true}
-                    withLabel={false}
-                    value={paymentPlan.benefitPlan}
-                    readOnly
-                /> : "",
+                ? `${paymentPlan.benefitPlan.code} ${paymentPlan.benefitPlan.name}` : "",
             paymentPlan => !!paymentPlan.periodicity ? paymentPlan.periodicity : "",
             paymentPlan => !!paymentPlan.dateValidFrom
                 ? formatDateFromISO(modulesManager, intl, paymentPlan.dateValidFrom)


### PR DESCRIPTION
… dropdown

[OP-1363](https://openimis.atlassian.net/browse/OP-1363)

Changes:
- I replaced the readOnly dropdown, which displayed the selected product, with a string that includes its code and name.

[OP-1363]: https://openimis.atlassian.net/browse/OP-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ