### PR TITLE
Creation of payment plan reads status linked criteria

### DIFF
--- a/src/dialogs/AdvancedCriteriaDialog.js
+++ b/src/dialogs/AdvancedCriteriaDialog.js
@@ -48,18 +48,25 @@ const AdvancedCriteriaDialog = ({
   const [filters, setFilters] = useState(getDefaultAppliedCustomFilters());
 
   const getBenefitPlanDefaultCriteria = () => {
-    const { jsonExt } = edited?.benefitPlan ?? {};
-    try {
-      const jsonData = JSON.parse(jsonExt);
-      return jsonData.advanced_criteria || [];
-    } catch (error) {
-      return [];
+    const jsonExt = edited?.benefitPlan?.jsonExt ?? '{}';
+    const jsonData = JSON.parse(jsonExt);
+
+    // Note: advanced_criteria is migrated from [filters] to {status: filters}
+    // For backward compatibility default status take on the old filters
+    let criteria = jsonData?.advanced_criteria || {};
+    if (Array.isArray(criteria)) {
+      return criteria;
     }
+
+    return criteria['ACTIVE'] || [];
   };
 
   useEffect(() => {
-    if (!getDefaultAppliedCustomFilters().length) {
+    const defaultAppliedCustomFilters = getDefaultAppliedCustomFilters();
+    if (!defaultAppliedCustomFilters.length) {
       setFilters(getBenefitPlanDefaultCriteria());
+    } else {
+      setFilters(defaultAppliedCustomFilters);
     }
   }, [edited]);
   


### PR DESCRIPTION
This is related to https://github.com/openimis/openimis-fe-individual_js/pull/89 and https://github.com/openimis/openimis-fe-social_protection_js/pull/102 Manually tested, gif as below

![payment_plan_create](https://github.com/user-attachments/assets/fb87c8b9-d871-494f-ab7f-81c37764fae9)

Without this change payment plan creations will not work (as seen on demo server). Kindly review @sniedzielski @delcroip 