### PR TITLE
set text beside icons OP-2578

### DIFF
--- a/src/components/ContributionPlanSearcher.js
+++ b/src/components/ContributionPlanSearcher.js
@@ -15,7 +15,7 @@ import { fetchContributionPlans, deleteContributionPlan } from "../actions";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import ContributionPlanFilter from "./ContributionPlanFilter";
-import { IconButton } from "@material-ui/core";
+import { Button } from "@material-ui/core";
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
 import {
@@ -90,28 +90,27 @@ class ContributionPlanSearcher extends Component {
         if (rights.includes(RIGHT_CONTRIBUTION_PLAN_UPDATE)) {
             result.push(
                 contributionPlan => !this.isDeletedFilterEnabled(contributionPlan) && withTooltip(
-                    <div>
-                        <IconButton
-                            href={contributionPlanPageLink(contributionPlan)}
-                            onClick={e => e.stopPropagation() && onDoubleClick(contributionPlan)}
-                            disabled={this.state.deleted.includes(contributionPlan.id)}>
-                            <EditIcon />
-                        </IconButton>
-                    </div>,
-                    formatMessage(intl, "contributionPlan", "editButton.tooltip")
+                    <Button
+                        href={contributionPlanPageLink(contributionPlan)}
+                        onClick={e => e.stopPropagation() && onDoubleClick(contributionPlan)}
+                        disabled={this.state.deleted.includes(contributionPlan.id)}
+                        startIcon={<EditIcon />}
+                    >
+                        {formatMessage(intl, "contributionPlan", "editButton.buttonText")}
+                    </Button>
                 )
             );
         }
         if (rights.includes(RIGHT_CONTRIBUTION_PLAN_DELETE)) {
             result.push(
                 contributionPlan => !this.isDeletedFilterEnabled(contributionPlan) && withTooltip(
-                    <div>
-                        <IconButton
-                            onClick={() => this.onDelete(contributionPlan)}
-                            disabled={this.state.deleted.includes(contributionPlan.id)}>
-                            <DeleteIcon />
-                        </IconButton>
-                    </div>,
+                    <Button
+                        onClick={() => this.onDelete(contributionPlan)}
+                        disabled={this.state.deleted.includes(contributionPlan.id)}
+                        startIcon={<DeleteIcon />}
+                    >
+                        {formatMessage(this.props.intl, "contributionPlan", "deleteButton.buttonText")}
+                    </Button>,
                     formatMessage(this.props.intl, "contributionPlan", "deleteButton.tooltip")
                 )
             );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,4 +1,6 @@
 {
+    "editButton.buttonText": "Edit",
+    "deleteButton.buttonText": "Delete",
     "contributionPlan.contributionPlans.page.title": "Contribution Plans",
     "contributionPlan.contributionPlans.searcher.results.title": "{contributionPlansTotalCount} Contribution Plans Found",
     "contributionPlan.contributionPlanBundles.page.title": "Contribution Plan Bundles",


### PR DESCRIPTION
Added descriptive text next to icon-only buttons to improve usability and accessibility.
According to [WCAG 2.1](https://www.w3.org/TR/WCAG21/) and usability best practices, relying on icons alone can create confusion since many icons do not have a universal meaning. By adding short descriptive labels, the interface becomes more intuitive, accessible to all users, and compliant with accessibility standards.