### PR TITLE
Fix: periodicity should be formatted as int [OP-2988]

### DIFF
--- a/src/components/ContributionPlanBundleFilter.js
+++ b/src/components/ContributionPlanBundleFilter.js
@@ -133,6 +133,7 @@ class ContributionPlanBundleFilter extends Component {
           <NumberInput
             module="contributionPlan"
             label="periodicity"
+            numberOfDecimals={0}
             min={
               !!this._filterValue("periodicity")
                 ? MIN_PERIODICITY_VALUE

--- a/src/components/ContributionPlanBundleHeadPanel.js
+++ b/src/components/ContributionPlanBundleHeadPanel.js
@@ -117,6 +117,7 @@ class ContributionPlanBundleHeadPanel extends FormPanel {
               module="contributionPlan"
               label="periodicity"
               required
+              numberOfDecimals={0}
               /**
                * @see min set to @see EMPTY_PERIODICITY_FILTER when filter unset to avoid @see NumberInput error message
                */

--- a/src/components/ContributionPlanFilter.js
+++ b/src/components/ContributionPlanFilter.js
@@ -99,6 +99,7 @@ class ContributionPlanFilter extends Component {
           <NumberInput
             module="contributionPlan"
             label="periodicity"
+            numberOfDecimals={0}
             /**
              * @see min set to @see EMPTY_PERIODICITY_VALUE when filter unset to avoid @see NumberInput error message
              */

--- a/src/components/ContributionPlanHeadPanel.js
+++ b/src/components/ContributionPlanHeadPanel.js
@@ -163,6 +163,7 @@ class ContributionPlanHeadPanel extends FormPanel {
               module="contributionPlan"
               label="periodicity"
               required
+              numberOfDecimals={0}
               /**
                * @see min set to @see EMPTY_PERIODICITY_FILTER when filter unset to avoid @see NumberInput error message
                */

--- a/src/components/PaymentPlanFilter.js
+++ b/src/components/PaymentPlanFilter.js
@@ -145,6 +145,7 @@ class PaymentPlanFilter extends Component {
           <NumberInput
             module="contributionPlan"
             label="periodicity"
+            numberOfDecimals={0}
             /**
              * @see min set to @see EMPTY_PERIODICITY_VALUE when filter unset to avoid @see NumberInput error message
              */

--- a/src/components/PaymentPlanHeadPanel.js
+++ b/src/components/PaymentPlanHeadPanel.js
@@ -279,6 +279,7 @@ class PaymentPlanHeadPanel extends FormPanel {
                                     readOnly={readOnly}
                                     label="periodicity"
                                     required
+                                    numberOfDecimals={0}
                                     /**
                                     * @see min set to @see EMPTY_PERIODICITY_FILTER when filter unset to avoid @see NumberInput error message
                                     */


### PR DESCRIPTION
# Description

Periodicity should be formatted as int instead of decimals

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires https://github.com/openimis/openimis-fe-core_js/pull/308
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira): https://openimis.atlassian.net/browse/OP-2988

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
