### PR TITLE
Disable Save when payment plan code is taken

### DIFF
--- a/src/components/PaymentPlanForm.js
+++ b/src/components/PaymentPlanForm.js
@@ -85,11 +85,12 @@ class PaymentPlanForm extends Component {
         return true;
       };
 
-    canSave = () =>  
+    canSave = () =>
         !this.isMandatoryFieldsEmpty() &&
         this.isPeriodicityValid() &&
         !!this.state.jsonExtValid &&
-        this.doesPaymentPlanChange();
+        this.doesPaymentPlanChange() &&
+        this.props.isCodeValid;
 
     save = paymentPlan => this.props.save(paymentPlan);
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -60,6 +60,7 @@
     "contributionPlan.paymentPlans.page.title": "Payment Plans",
     "contributionPlan.paymentPlans.searcher.results.title": "{paymentPlansTotalCount} Payment Plans Found",
     "paymentPlan.code": "Code",
+    "paymentPlan.codeTaken": "Payment plan code already exists",
     "paymentPlan.name": "Name",
     "paymentPlan.calculation": "Calculation Rule",
     "paymentPlan.benefitPlan": "Benefit Product",


### PR DESCRIPTION
# Description

The payment-plan creation form previously allowed users to attempt a Save even when the asynchronous code-uniqueness validation reported that the entered code was already taken.  When the conflict was reported, the field-level error rendered the raw translation key `paymentPlan.codeTaken` instead of a human-readable message because no English string was registered for that key.

This PR fixes both issues:

1. Adds the missing `paymentPlan.codeTaken` English translation so the field-level error displays *"Payment plan code already exists"* instead of the raw key.
2. Includes `isCodeValid` in the form's `canSave()` predicate so the Save button is disabled while the duplicate-code error is active, mirroring the existing `ContributionPlanForm` pattern.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)

[E2E Payment Tests](https://github.com/openimis/openimis-dist_dkr/pull/99)

---

## Changes

### Translation
- [x] Add `paymentPlan.codeTaken` → *"Payment plan code already exists"* in `src/translations/en.json`

### Form Validation
- [x] Add `this.props.isCodeValid` check to `canSave()` in `PaymentPlanForm.js`
- [x] `isCodeValid` was already wired through `mapStateToProps` from `state.contributionPlan?.validationFields?.paymentPlanCode?.isValid` — no new redux plumbing needed

---

## Behaviour Before / After

| Scenario | Before | After |
|---|---|---|
| Type a duplicate code | Raw key `paymentPlan.codeTaken` shown under the field | Message *"Payment plan code already exists"* shown under the field |
| Save button while duplicate error is active | Enabled (allows submit attempt) | Disabled (prevents submit) |
| Save button after fixing the code to a unique value | Enabled | Enabled |

---

## Demo

_To be added after manual verification._

## Checklist

- [x] Translation key added matches the existing `paymentPlan.*` namespace convention
- [x] `canSave()` change matches the existing `ContributionPlanForm` / `ContributionPlanBundleForm` pattern (consistency across forms)
- [x] No new redux state introduced — reuses existing `validationFields.paymentPlanCode.isValid`
- [x] Build succeeds (`npm run build`)
- [x] Verified manually in the running stack with E2E coverage in `openimis-dist_dkr`