### PR TITLE
Fix undefined Benefit Product on payment plan listing

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -281,7 +281,16 @@ function reducer(
         ...state,
         fetchingPaymentPlans: false,
         fetchedPaymentPlans: true,
-        paymentPlans: parseData(action.payload.data.paymentPlan),
+        paymentPlans: parseData(action.payload.data.paymentPlan)?.map((paymentPlan) => ({
+          ...paymentPlan,
+          // benefitPlan is double-encoded by the backend (graphene JSONString
+          // wraps a json.dumps(...) result).  Parse it here so consumers like
+          // PaymentPlanSearcher and the BenefitPlanPicker receive an object
+          // and can read code/name on the very first render.
+          benefitPlan: !!paymentPlan.benefitPlan
+            ? JSON.parse(JSON.parse(paymentPlan.benefitPlan))
+            : null,
+        })),
         paymentPlansPageInfo: pageInfo(action.payload.data.paymentPlan),
         paymentPlansTotalCount: !!action.payload.data.paymentPlan
           ? action.payload.data.paymentPlan.totalCount


### PR DESCRIPTION
# Description

On the Payment Plans listing page (`/front/paymentPlans`), the **Benefit Product** column rendered each row's program picker label as *"undefined…"* on the very first render after the search results came in.  Any subsequent state change (filter input, sort, etc.) made the value appear correctly, which made the bug look intermittent.

Root cause: the backend serialises the `benefitPlan` field of `paymentPlan` as a graphene `JSONString` wrapping a `json.dumps(...)` result, so the value arrives at the frontend **double-encoded**.  The list reducer (`CONTRIBUTIONPLAN_PAYMENTPLANS_RESP`) was passing it through unparsed, while `PaymentPlanSearcher.itemFormatters` only did a single inline `JSON.parse`.  Single-parsing a double-encoded string produces another string (not an object), so `BenefitPlanPicker` rendered `${value.code} ${value.name}` as `"undefined undefined"`.  A second render re-ran the inline parse on the now-single-encoded string and produced the object — masking the bug after any user interaction.

This PR parses `benefitPlan` once in the reducer (double parse), mirroring the existing `CONTRIBUTIONPLAN_CONTRIBUTIONPLANS_RESP` handler, so consumers receive a proper object on the first render.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)

[E2E Payment Tests](https://github.com/openimis/openimis-dist_dkr/pull/99)

---

## Changes

- [x] Parse `benefitPlan` (double parse, with null guard) in `CONTRIBUTIONPLAN_PAYMENTPLANS_RESP` so the list reducer produces objects with `code`/`name` already accessible.
- [x] No change to `PaymentPlanSearcher.js` — its existing defensive inline parse becomes a no-op when the value is already an object.

---

## Behaviour Before / After

| Scenario | Before | After |
|---|---|---|
| Initial in-app navigation to `/front/paymentPlans` | Benefit Product column shows *"undefined…"* | Benefit Product column shows the program code/name |
| Records re-fetched via Search filter | First render shows *"undefined…"*, fixed after any subsequent state change | Correct value on the first render |
| Hard browser refresh | Already worked | Unchanged |

---

## Demo

_To be added after manual verification._

## Checklist

- [x] Pattern matches the existing `CONTRIBUTIONPLAN_CONTRIBUTIONPLANS_RESP` reducer handler
- [x] Null/undefined `benefitPlan` is guarded (returns `null` instead of throwing on `JSON.parse`)
- [x] Defensive inline parsing in `PaymentPlanSearcher` is preserved as a no-op fallback
- [x] No new redux state introduced; no API/GraphQL changes
- [x] Verified manually in a running stack