### PR TITLE
refactor(PaymentPlanForm): convert to functional component and fix va…

### DIFF
--- a/src/components/PaymentPlanForm.jsx
+++ b/src/components/PaymentPlanForm.jsx
@@ -31,7 +31,6 @@ const PaymentPlanForm = ({
   paymentPlanId,
   save,
   isReplacing = false,
-  classes,
   modulesManager,
   fetchPaymentPlan,
   clearPaymentPlan,
@@ -56,6 +55,9 @@ const PaymentPlanForm = ({
       clearPaymentPlan();
       setPaymentPlan({});
     }
+    return () => {
+      clearPaymentPlan();
+    };
   }, [paymentPlanId, modulesManager, fetchPaymentPlan, clearPaymentPlan]);
 
   useEffect(() => {
@@ -101,8 +103,9 @@ const PaymentPlanForm = ({
     !isMandatoryFieldsEmpty() &&
     isPeriodicityValid() &&
     !!jsonExtValid &&
+    !!requiredValid &&
     doesPaymentPlanChange(),
-    [isMandatoryFieldsEmpty, isPeriodicityValid, jsonExtValid, doesPaymentPlanChange]
+    [isMandatoryFieldsEmpty, isPeriodicityValid, jsonExtValid, requiredValid, doesPaymentPlanChange]
   );
 
   const handleSave = useCallback((paymentPlan) => save(paymentPlan), [save]);
@@ -116,33 +119,30 @@ const PaymentPlanForm = ({
 
   const shouldBeLocked = Boolean(clientMutationId);
 
-    setJsonExtValid = (valid) => this.setState({ jsonExtValid: !!valid });
-    setRequiredValid = (valid) => this.setState({ requiredValid: !!valid });
-
-    return (
-      <StyledForm className={shouldBeLocked ? "lockedPage" : null}>
-        <Helmet title={formatMessageWithValues(this.props.intl, "paymentPlan", "paymentPlan.page.title", this.titleParams())} />
-        <Form
-            module="paymentPlan"
-            title="paymentPlan.page.title"
-            titleParams={titleParams()}
-            edited={paymentPlan}
-            back={back}
-            canSave={canSave}
-            save={handleSave}
-            onEditedChanged={onEditedChanged}
-            HeadPanel={PaymentPlanHeadPanel}
-            mandatoryFieldsEmpty={isMandatoryFieldsEmpty()}
-            saveTooltip={formatMessage(intl, "paymentPlan", `saveButton.tooltip.${canSave() ? 'enabled' : 'disabled'}`)}
-            setJsonExtValid={setJsonExtValid}
-            setRequiredValid={setRequiredValid}
-            paymentPlanId={paymentPlanId}
-            isReplacing={isReplacing}
-            openDirty={save}
-            readOnly={shouldBeLocked}
-        />
-      </StyledForm>
-    )
+  return (
+    <StyledForm className={shouldBeLocked ? "lockedPage" : null}>
+      <Helmet title={formatMessageWithValues(intl, "paymentPlan", "paymentPlan.page.title", titleParams())} />
+      <Form
+          module="paymentPlan"
+          title="paymentPlan.page.title"
+          titleParams={titleParams()}
+          edited={paymentPlan}
+          back={back}
+          canSave={canSave}
+          save={handleSave}
+          onEditedChanged={onEditedChanged}
+          HeadPanel={PaymentPlanHeadPanel}
+          mandatoryFieldsEmpty={isMandatoryFieldsEmpty()}
+          saveTooltip={formatMessage(intl, "paymentPlan", `saveButton.tooltip.${canSave() ? 'enabled' : 'disabled'}`)}
+          setJsonExtValid={setJsonExtValid}
+          setRequiredValid={setRequiredValid}
+          paymentPlanId={paymentPlanId}
+          isReplacing={isReplacing}
+          openDirty={save}
+          readOnly={shouldBeLocked}
+      />
+    </StyledForm>
+  )
 }
 
 const mapStateToProps = state => ({


### PR DESCRIPTION

- Remove unused `classes` prop.
- Add cleanup function in useEffect to clear payment plan on unmount.
- Add `requiredValid` to validation dependency array.
- Replace incorrect `this.setState` calls with proper functional state management.


A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
